### PR TITLE
Default Value for options in createGraphQLHandler

### DIFF
--- a/__tests__/unit/handler-test.js
+++ b/__tests__/unit/handler-test.js
@@ -43,7 +43,7 @@ describe("Unit | handler", function () {
     expect(response.data.errors[0].message).toBe("foo");
   });
 
-  it('creates handler with no options provided', function () {
+  it('supports creating handler with no options provided', function () {
     expect(() => createGraphQLHandler(graphQLSchema, mirageSchema)).toThrow("Cannot destructure property `context` of 'undefined' or 'null'.")
   })
 });

--- a/__tests__/unit/handler-test.js
+++ b/__tests__/unit/handler-test.js
@@ -43,7 +43,9 @@ describe("Unit | handler", function () {
     expect(response.data.errors[0].message).toBe("foo");
   });
 
-  it('supports creating handler with no options provided', function () {
-    expect(() => createGraphQLHandler(graphQLSchema, mirageSchema)).toThrow("Cannot destructure property `context` of 'undefined' or 'null'.")
-  })
+  it("supports creating handler with no options provided", function () {
+    expect(() => createGraphQLHandler(graphQLSchema, mirageSchema)).not.toThrow(
+      "Cannot destructure property `context` of 'undefined' or 'null'."
+    );
+  });
 });

--- a/__tests__/unit/handler-test.js
+++ b/__tests__/unit/handler-test.js
@@ -23,23 +23,27 @@ describe("Unit | handler", function () {
     resolvers,
   });
 
-  it("creates a GraphQL field resolver", function () {
-    expect(createFieldResolver).toHaveBeenCalledWith(resolvers);
-  });
+  // it("creates a GraphQL field resolver", function () {
+  //   expect(createFieldResolver).toHaveBeenCalledWith(resolvers);
+  // });
 
-  it("ensures the GraphQL schema is executable", function () {
-    expect(ensureExecutableGraphQLSchema).toHaveBeenCalledWith(graphQLSchema);
-  });
+  // it("ensures the GraphQL schema is executable", function () {
+  //   expect(ensureExecutableGraphQLSchema).toHaveBeenCalledWith(graphQLSchema);
+  // });
 
-  it("ensures models are created in the Mirage schema", function () {
-    expect(ensureModels).toHaveBeenCalledWith({ graphQLSchema, mirageSchema });
-  });
+  // it("ensures models are created in the Mirage schema", function () {
+  //   expect(ensureModels).toHaveBeenCalledWith({ graphQLSchema, mirageSchema });
+  // });
 
-  it("responds with 500 if GraphQL throws an exception", function () {
-    const response = graphQLHandler(null, { requestBody: "{}" });
+  // it("responds with 500 if GraphQL throws an exception", function () {
+  //   const response = graphQLHandler(null, { requestBody: "{}" });
 
-    expect(response).toBeInstanceOf(Response);
-    expect(response.code).toBe(500);
-    expect(response.data.errors[0].message).toBe("foo");
-  });
+  //   expect(response).toBeInstanceOf(Response);
+  //   expect(response.code).toBe(500);
+  //   expect(response.data.errors[0].message).toBe("foo");
+  // });
+
+  it('creates handler with no options provided', function () {
+    expect(() => createGraphQLHandler(graphQLSchema, mirageSchema)).not.toThrow("Cannot destructure property `context` of 'undefined' or 'null'.")
+  })
 });

--- a/__tests__/unit/handler-test.js
+++ b/__tests__/unit/handler-test.js
@@ -23,27 +23,27 @@ describe("Unit | handler", function () {
     resolvers,
   });
 
-  // it("creates a GraphQL field resolver", function () {
-  //   expect(createFieldResolver).toHaveBeenCalledWith(resolvers);
-  // });
+  it("creates a GraphQL field resolver", function () {
+    expect(createFieldResolver).toHaveBeenCalledWith(resolvers);
+  });
 
-  // it("ensures the GraphQL schema is executable", function () {
-  //   expect(ensureExecutableGraphQLSchema).toHaveBeenCalledWith(graphQLSchema);
-  // });
+  it("ensures the GraphQL schema is executable", function () {
+    expect(ensureExecutableGraphQLSchema).toHaveBeenCalledWith(graphQLSchema);
+  });
 
-  // it("ensures models are created in the Mirage schema", function () {
-  //   expect(ensureModels).toHaveBeenCalledWith({ graphQLSchema, mirageSchema });
-  // });
+  it("ensures models are created in the Mirage schema", function () {
+    expect(ensureModels).toHaveBeenCalledWith({ graphQLSchema, mirageSchema });
+  });
 
-  // it("responds with 500 if GraphQL throws an exception", function () {
-  //   const response = graphQLHandler(null, { requestBody: "{}" });
+  it("responds with 500 if GraphQL throws an exception", function () {
+    const response = graphQLHandler(null, { requestBody: "{}" });
 
-  //   expect(response).toBeInstanceOf(Response);
-  //   expect(response.code).toBe(500);
-  //   expect(response.data.errors[0].message).toBe("foo");
-  // });
+    expect(response).toBeInstanceOf(Response);
+    expect(response.code).toBe(500);
+    expect(response.data.errors[0].message).toBe("foo");
+  });
 
   it('creates handler with no options provided', function () {
-    expect(() => createGraphQLHandler(graphQLSchema, mirageSchema)).not.toThrow("Cannot destructure property `context` of 'undefined' or 'null'.")
+    expect(() => createGraphQLHandler(graphQLSchema, mirageSchema)).toThrow("Cannot destructure property `context` of 'undefined' or 'null'.")
   })
 });

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -51,7 +51,7 @@ import { graphql } from "graphql";
 export function createGraphQLHandler(
   graphQLSchema,
   mirageSchema,
-  { context = {}, resolvers, root }
+  { context = {}, resolvers, root } = {}
 ) {
   const contextValue = { ...context, mirageSchema };
   const fieldResolver = createFieldResolver(resolvers);


### PR DESCRIPTION
When `createGraphQLHandler` handler is used without an options object, as is commonly done in the docs, an error is encountered:

`TypeError: Cannot destructure property `context` of 'undefined' or 'null'.`

Since options is undefined, `context` does not get assigned its default of an empty object. In order for context to be assigned its default, options must also be assigned to a default object.