### PR TITLE
Remove b2a dependency

### DIFF
--- a/lib/relay-pagination.js
+++ b/lib/relay-pagination.js
@@ -1,8 +1,9 @@
-const ENCODE = typeof btoa !== "undefined"
-  ? btoa
-  : typeof Buffer !== "undefined"
-  ? (str) => Buffer.from(str).toString("base64")
-  : (str) => str;
+const ENCODE =
+  typeof btoa !== "undefined"
+    ? btoa
+    : typeof Buffer !== "undefined"
+    ? (str) => Buffer.from(str).toString("base64")
+    : (str) => str;
 
 const RELAY_ARGS = ["after", "before", "first", "last"];
 

--- a/lib/relay-pagination.js
+++ b/lib/relay-pagination.js
@@ -1,11 +1,8 @@
-/**
- * Encodes a string.
- *
- * @callback encode
- * @param {string} str
- * @returns {string}
- */
-import { btoa } from "b2a";
+const ENCODE = typeof btoa !== "undefined"
+  ? btoa
+  : typeof Buffer !== "undefined"
+  ? (str) => Buffer.from(str).toString("base64")
+  : (str) => str;
 
 const RELAY_ARGS = ["after", "before", "first", "last"];
 
@@ -42,7 +39,7 @@ function hasField(type, fieldName) {
  * @see {@link https://relay.dev/graphql/connections.htm#sec-Edge-Types}
  * @returns {Object[]} A list of Relay connection edges mapped from the records.
  */
-export function getEdges(records, args, typeName, encode = btoa) {
+export function getEdges(records, args, typeName, encode = ENCODE) {
   const { after, before, first, last } = args;
   const afterIndex = getIndexOfRecord(records, after, typeName, encode);
   const beforeIndex = getIndexOfRecord(records, before, typeName, encode);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "b2a": "^1.1.2",
     "graphql": "^15.0.0",
     "miragejs": "^0.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,11 +1326,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
   integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
-b2a@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/b2a/-/b2a-1.1.2.tgz#3bb0a7dbc0931c84ac97722fa4f5f51ba0a7d831"
-  integrity sha512-Ee7SUAyWeIx4ICRygOi7dVlGpHRxynsaLIZwOtHtGKls3LhLchTRk5KrI0O8ioWqy94ikkE8Z2Li3LWNd027/A==
-
 babel-eslint@^10.0.2:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"


### PR DESCRIPTION
This PR removes the `b2a` dependency. There seems to be some problem with loading this dependency if Mirage GraphQL is imported in Mirage's REPL. Instead, we assume the code is running in the browser or Node.

The `b2a` library was only used in one place when creating opaque Relay pagination node IDs. If all else fails, default encoding falls back to a passthrough function.