### PR TITLE
Add a build to the project for npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /coverage/
+/dist/
 /node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /**/*__mocks__/
 /.github/
 /__tests__/
+/build/
 /coverage/
 /.eslintrc.js
 /babel.config.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,4 +9,21 @@ module.exports = {
       },
     ],
   ],
+  overrides: [
+    {
+      plugins: [
+        ["@babel/plugin-transform-destructuring", { loose: true }],
+        ["@babel/plugin-transform-spread", { loose: true }],
+      ],
+      env: {
+        cjs: {
+          presets: [["@babel/preset-env", { modules: "commonjs" }]],
+        },
+        mjs: {
+          presets: [["@babel/preset-env", { modules: false }]],
+          plugins: [["./build/imports-extension", { extension: "mjs" }]],
+        },
+      },
+    },
+  ],
 };

--- a/build/imports-extension.js
+++ b/build/imports-extension.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/**
+ * Adds extension to all paths imported inside MJS files
+ *
+ * Transforms:
+ *  import { foo } from "./bar";
+ *  export { foo } from "./bar";
+ *
+ * to:
+ *  import { foo } from "./bar.mjs";
+ *  export { foo } from "./bar.mjs";
+ */
+module.exports = function addExtensionToImportPaths(context, { extension }) {
+  const { types } = context;
+
+  function replaceImportPath(path) {
+    if (!path.node.source) {
+      return;
+    }
+
+    const source = path.node.source.value;
+
+    if (source.startsWith("./") || source.startsWith("../")) {
+      const newSourceNode = types.stringLiteral(source + "." + extension);
+
+      path.get("source").replaceWith(newSourceNode);
+    }
+  }
+
+  return {
+    visitor: {
+      ImportDeclaration: replaceImportPath,
+      ExportNamedDeclaration: replaceImportPath,
+    },
+  };
+};

--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const babel = require("@babel/core");
+const fs = require("fs");
+const path = require("path");
+
+const DIST_PATH = "./dist";
+const SRC_PATH = "./lib";
+
+function babelBuild(srcPath, options) {
+  options.comments = false;
+
+  return babel.transformFileSync(srcPath, options).code + "\n";
+}
+
+function readdirRecursive(dirPath, opts = {}) {
+  const result = [];
+  const { ignoreDir } = opts;
+
+  for (const dirent of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const { name } = dirent;
+
+    if (!dirent.isDirectory()) {
+      result.push(name);
+      continue;
+    }
+
+    if (ignoreDir && ignoreDir.test(name)) {
+      continue;
+    }
+
+    const list = readdirRecursive(path.join(dirPath, name), opts).map((f) =>
+      path.join(name, f)
+    );
+
+    result.push(...list);
+  }
+
+  return result;
+}
+
+function rmdirRecursive(dirPath) {
+  if (fs.existsSync(dirPath)) {
+    for (const dirent of fs.readdirSync(dirPath, { withFileTypes: true })) {
+      const fullPath = path.join(dirPath, dirent.name);
+
+      if (dirent.isDirectory()) {
+        rmdirRecursive(fullPath);
+      } else {
+        fs.unlinkSync(fullPath);
+      }
+    }
+
+    fs.rmdirSync(dirPath);
+  }
+}
+
+if (require.main === module) {
+  rmdirRecursive(DIST_PATH);
+
+  fs.mkdirSync(DIST_PATH);
+
+  const srcFiles = readdirRecursive(SRC_PATH, { ignoreDir: /^__.*__$/ });
+
+  for (const filepath of srcFiles) {
+    const srcPath = path.join(SRC_PATH, filepath);
+    const destPath = path.join(DIST_PATH, filepath);
+    const cjs = babelBuild(srcPath, { envName: "cjs" });
+    const mjs = babelBuild(srcPath, { envName: "mjs" });
+
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.writeFileSync(destPath, cjs);
+    fs.writeFileSync(destPath.replace(/\.js$/, "-mjs.js"), mjs);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,0 @@
-import { createGraphQLHandler } from "./lib/handler";
-import mirageGraphQLFieldResolver from "./lib/resolvers/mirage";
-
-export { createGraphQLHandler, mirageGraphQLFieldResolver };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,8 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ["lib/**/*.js"],
   coveragePathIgnorePatterns: [
+    "<rootDir>/lib/index.js",
     "<rootDir>/lib/resolvers/default.js",
-    "<rootDir>/lib/resolvers/index.js",
   ],
   coverageThreshold: {
     global: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,4 @@
+import { createGraphQLHandler } from "./handler";
+import mirageGraphQLFieldResolver from "./resolvers/mirage";
+
+export { createGraphQLHandler, mirageGraphQLFieldResolver };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@miragejs/graphql",
   "version": "0.1.1",
   "description": "A library for handling GraphQL requests with Mirage JS",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "module": "dist/index-mjs.js",
   "keywords": [
     "pretender",
     "prototype",
@@ -22,6 +23,7 @@
   },
   "scripts": {
     "lint": "eslint .",
+    "prepublishOnly": "node build",
     "prettier:check": "prettier --list-different '**/*.js'",
     "prettier:update": "prettier --write .",
     "test": "jest"


### PR DESCRIPTION
This PR adds a build to the project which will run before we publish to npm. The build setup borrows from the [GraphQL JS build setup](https://github.com/graphql/graphql-js/blob/master/resources/build-npm.js), which is pretty straight forward and leans on Babel to do all the work.

The build will output two types of files to the `dist` folder:
* Common JS
* ES modules with some Babel transpilation

Adding the build should help resolve a couple of open issues:
* #3 
* https://github.com/miragejs/site/issues/264