### PR TITLE
Fix for resolving non-list union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This guide assumes most of its readers are already using GraphQL in their apps a
 * [Mirage GraphQL Assumptions](#mirage-graphql-assumptions)
   * [You Don't Need Mirage Models](#you-dont-need-mirage-models)
   * [Arguments from GraphQL Queries Map to Field Names of the Return Type](#arguments-from-graphql-queries-map-to-field-names-of-the-return-type)
+  * [Miscellaneous Assumptions](#miscellaneous-assumptions)
 * [Example Use Cases](#example-use-cases)
   * [Example Schema](#example-schema)
   * [Example: Find Person by ID](#example-find-person-by-id)
@@ -75,6 +76,10 @@ In many cases, you need to [tell Mirage about the models](https://miragejs.com/d
 #### Arguments from GraphQL Queries Map to Field Names of the Return Type
 
 Mirage GraphQL uses arguments to filter records from Mirage's database. This isn't very useful for testing, as you only need to seed Mirage's database with the exact records you need for a given test. It's more useful when using Mirage for development where filtering and pagination may be desired for a more realistic user experience.
+
+#### Miscellaneous Assumptions
+
+* Fields that should resolve to a single object of a union type are resolved by taking the first appropriate record from Mirage's database. This is how Mirage GraphQL automatically resolves in this scenario. As with all automatic resolution, if you need to include some additional logic, you'll need to supply your own resolver.
 
 ### Example Use Cases
 

--- a/__tests__/gql/queries/object-kitchen-sink.gql
+++ b/__tests__/gql/queries/object-kitchen-sink.gql
@@ -78,5 +78,8 @@ query TestObject($id: ID!) {
     unionNestedNonNullField(twoName: "bar") {
       ...testUnion
     }
+    unionSingularField {
+      ...testUnion
+    }
   }
 }

--- a/__tests__/gql/schema.gql
+++ b/__tests__/gql/schema.gql
@@ -60,6 +60,7 @@ type Query {
   testUnion(oneName: String, twoName: String): [TestUnion]
   testUnionNonNull(oneName: String, twoName: String): [TestUnion]!
   testUnionNestedNonNull(oneName: String, twoName: String): [TestUnion!]!
+  testUnionSingular(oneName: String, twoName: String): TestUnion
 }
 
 type TestCategory {

--- a/__tests__/gql/schema.gql
+++ b/__tests__/gql/schema.gql
@@ -100,6 +100,7 @@ type TestObject {
   unionField: [TestUnion]
   unionNonNullField(oneName: String): [TestUnion]!
   unionNestedNonNullField(twoName: String): [TestUnion!]!
+  unionSingularField: TestUnion
 }
 
 type TestOption {

--- a/__tests__/integration/queries/object-kitchen-sink-test.js
+++ b/__tests__/integration/queries/object-kitchen-sink-test.js
@@ -4,7 +4,6 @@ import { query, startServer } from "@tests/integration/setup";
 describe("Integration | queries | object", function () {
   test("query for test object", async function () {
     const server = startServer();
-
     const testCategory = server.create("test-category", { name: "cat" });
     const testImpl = server.create("test-impl-one", { label: "impl" });
     const testOptions = server.createList("test-option", 1, { name: "opt" });
@@ -70,6 +69,7 @@ describe("Integration | queries | object", function () {
       ],
       unionNonNullField: [{ id: "1", oneName: "foo" }],
       unionNestedNonNullField: [{ id: "1", twoName: "bar" }],
+      unionSingularField: { id: "1", oneName: "foo" },
     });
   });
 });

--- a/__tests__/unit/resolvers/mirage-field-resolver-test.js
+++ b/__tests__/unit/resolvers/mirage-field-resolver-test.js
@@ -62,7 +62,22 @@ describe("Unit | resolvers | mirage field resolver", function () {
   });
 
   describe("polymorphic types", function () {
-    it("can resolve union types", function () {
+    it("can resolve union object types", function () {
+      const info = { returnType: queryFields.testUnionSingular.type };
+
+      mirageGraphQLFieldResolver(obj, args, context, info);
+
+      expect(resolveUnion).toHaveBeenCalledWith(
+        obj,
+        args,
+        context,
+        info,
+        false,
+        info.returnType
+      );
+    });
+
+    it("can resolve union list types", function () {
       const {
         type: { ofType: unionType },
       } = queryFields.testUnion;
@@ -75,6 +90,7 @@ describe("Unit | resolvers | mirage field resolver", function () {
         args,
         context,
         info,
+        true,
         unionType
       );
     });

--- a/lib/resolvers/mirage.js
+++ b/lib/resolvers/mirage.js
@@ -32,7 +32,7 @@ export default function mirageGraphQLFieldResolver(obj, args, context, info) {
   return isInterfaceType(type)
     ? resolveInterface(obj, args, context, info, type)
     : isUnionType(type)
-    ? resolveUnion(obj, args, context, info, type)
+    ? resolveUnion(obj, args, context, info, isList, type)
     : !isObjectType(type)
     ? resolveDefault(...arguments)
     : isList

--- a/lib/resolvers/union.js
+++ b/lib/resolvers/union.js
@@ -9,14 +9,16 @@ import { getRecords } from "../orm/records";
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info
+ * @param {Boolean} isList
+ * @param {Object} type
  * @see {@link https://graphql.org/learn/execution/#root-fields-resolvers}
  * @returns {Object[]} A list of records of many types from Mirage's database.
  */
-export default function resolveUnion(_obj, args, context, _info, type) {
+export default function resolveUnion(_obj, args, context, _info, isList, type) {
   const types = type.getTypes();
   const recordsForTypes = types.reduce(function (records, type) {
     return [...records, ...getRecords(type, args, context.mirageSchema)];
   }, []);
 
-  return recordsForTypes;
+  return isList ? recordsForTypes : recordsForTypes[0];
 }


### PR DESCRIPTION
This PR fixes an issue where Mirage GraphQL assumes any union type field should resolve to a list. Fixes #12.