### PR TITLE
fix modules build issue

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,7 +21,7 @@ module.exports = {
         },
         mjs: {
           presets: [["@babel/preset-env", { modules: false }]],
-          plugins: [["./build/imports-extension", { extension: "mjs" }]],
+          plugins: [["./build/imports-suffix", { suffix: "-mjs" }]],
         },
       },
     },

--- a/build/imports-suffix.js
+++ b/build/imports-suffix.js
@@ -1,17 +1,17 @@
 "use strict";
 
 /**
- * Adds extension to all paths imported inside MJS files
+ * Adds suffix to all paths imported inside MJS files
  *
  * Transforms:
  *  import { foo } from "./bar";
  *  export { foo } from "./bar";
  *
  * to:
- *  import { foo } from "./bar.mjs";
- *  export { foo } from "./bar.mjs";
+ *  import { foo } from "./bar-mjs";
+ *  export { foo } from "./bar-mjs";
  */
-module.exports = function addExtensionToImportPaths(context, { extension }) {
+module.exports = function addExtensionToImportPaths(context, { suffix }) {
   const { types } = context;
 
   function replaceImportPath(path) {
@@ -22,7 +22,7 @@ module.exports = function addExtensionToImportPaths(context, { extension }) {
     const source = path.node.source.value;
 
     if (source.startsWith("./") || source.startsWith("../")) {
-      const newSourceNode = types.stringLiteral(source + "." + extension);
+      const newSourceNode = types.stringLiteral(source + suffix);
 
       path.get("source").replaceWith(newSourceNode);
     }


### PR DESCRIPTION
Currently, the `module` build is broken, as a generated `dist` folder will contain only `*.js` and `*-mjs.js` files, but `*-mjs.js` files will try to import from `*.mjs` files which don't exist. This PR fixes that by changing the imports to use correct paths.

cc @jneurock 