### PR TITLE
Fix related record filtering/fix union resolution

### DIFF
--- a/__tests__/gql/queries/object-kitchen-sink.gql
+++ b/__tests__/gql/queries/object-kitchen-sink.gql
@@ -45,6 +45,9 @@ query TestObject($id: ID!) {
     hasManyField {
       ...testOption
     }
+    hasManyFilteredField(name: "Foo") {
+      ...testOption
+    }
     hasManyNonNullField {
       ...testOption
     }

--- a/__tests__/gql/queries/object-kitchen-sink.gql
+++ b/__tests__/gql/queries/object-kitchen-sink.gql
@@ -69,6 +69,21 @@ query TestObject($id: ID!) {
     relayConnectionField(first: 1, after: "VGVzdFJlbGF5Tm9kZTox") {
       ...testRelayConnection
     }
+    relayConnectionFilteredField(first: 1, color: "blue") {
+      edges {
+        cursor
+        node {
+          id
+          color
+        }
+      }
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
+      }
+    }
     relayConnectionNonNullField(last: 1, before: "VGVzdFJlbGF5Tm9kZToz") {
       ...testRelayConnection
     }

--- a/__tests__/gql/schema.gql
+++ b/__tests__/gql/schema.gql
@@ -93,6 +93,11 @@ type TestObject {
     first: Int
     after: String
   ): TestRelayConnection
+  relayConnectionFilteredField(
+    first: Int,
+    after: String,
+    color: String
+  ): TestRelayConnection
   relayConnectionNonNullField(
     last: Int
     before: String

--- a/__tests__/gql/schema.gql
+++ b/__tests__/gql/schema.gql
@@ -84,6 +84,7 @@ type TestObject {
   belongsToField: TestCategory
   belongsToNonNullField: TestCategory!
   hasManyField: [TestOption]
+  hasManyFilteredField(name: String): [TestOption]
   hasManyNonNullField: [TestOption]!
   hasManyNestedNonNullField: [TestOption!]!
   interfaceField: TestInterface

--- a/__tests__/integration/queries/object-kitchen-sink-test.js
+++ b/__tests__/integration/queries/object-kitchen-sink-test.js
@@ -1,17 +1,29 @@
 import objectKitchenSinkQuery from "@tests/gql/queries/object-kitchen-sink.gql";
 import { query, startServer } from "@tests/integration/setup";
 
+function seedUnassociatedRecords(server) {
+  server.createList("test-option", 2);
+  server.create("test-union-one");
+  server.create("test-union-two");
+}
+
 describe("Integration | queries | object", function () {
   test("query for test object", async function () {
     const server = startServer();
     const testCategory = server.create("test-category", { name: "cat" });
     const testImpl = server.create("test-impl-one", { label: "impl" });
     const testOptions = server.createList("test-option", 1, { name: "opt" });
+    const filterableTestOptions = [
+      ...testOptions,
+      server.create("test-option", { name: "Foo" })
+    ];
     const testRelayNodes = server.createList("test-relay-node", 3);
     const testUnions = [
       server.create("test-union-one", { oneName: "foo" }),
       server.create("test-union-two", { twoName: "bar" }),
     ];
+
+    seedUnassociatedRecords(server);
 
     server.create("test-object", {
       size: "XL",
@@ -19,6 +31,7 @@ describe("Integration | queries | object", function () {
       belongsToField: testCategory,
       belongsToNonNullField: testCategory,
       hasManyField: testOptions,
+      hasManyFilteredField: filterableTestOptions,
       hasManyNonNullField: testOptions,
       hasManyNestedNonNullField: testOptions,
       interfaceField: testImpl,
@@ -28,6 +41,7 @@ describe("Integration | queries | object", function () {
       unionField: testUnions,
       unionNonNullField: testUnions,
       unionNestedNonNullField: testUnions,
+      unionSingularField: testUnions[0]
     });
 
     const { testObject } = await query(objectKitchenSinkQuery, {
@@ -41,6 +55,7 @@ describe("Integration | queries | object", function () {
       belongsToField: { id: "1", name: "cat" },
       belongsToNonNullField: { id: "1", name: "cat" },
       hasManyField: [{ id: "1", name: "opt" }],
+      hasManyFilteredField: [{ id: "2", name: "Foo" }],
       hasManyNonNullField: [{ id: "1", name: "opt" }],
       hasManyNestedNonNullField: [{ id: "1", name: "opt" }],
       interfaceField: { id: "1", label: "impl" },

--- a/__tests__/integration/queries/object-kitchen-sink-test.js
+++ b/__tests__/integration/queries/object-kitchen-sink-test.js
@@ -17,7 +17,14 @@ describe("Integration | queries | object", function () {
       ...testOptions,
       server.create("test-option", { name: "Foo" }),
     ];
-    const testRelayNodes = server.createList("test-relay-node", 3);
+    const blueTestRelayNode = server.create(
+      "test-relay-node",
+      { color: "blue" },
+    );
+    const testRelayNodes = [
+      blueTestRelayNode,
+      ...server.createList("test-relay-node", 2),
+    ];
     const testUnions = [
       server.create("test-union-one", { oneName: "foo" }),
       server.create("test-union-two", { twoName: "bar" }),
@@ -37,6 +44,7 @@ describe("Integration | queries | object", function () {
       interfaceField: testImpl,
       interfaceNonNullField: testImpl,
       relayConnectionField: testRelayNodes,
+      relayConnectionFilteredField: testRelayNodes,
       relayConnectionNonNullField: testRelayNodes,
       unionField: testUnions,
       unionNonNullField: testUnions,
@@ -67,6 +75,18 @@ describe("Integration | queries | object", function () {
           hasNextPage: true,
           startCursor: "VGVzdFJlbGF5Tm9kZToy",
           endCursor: "VGVzdFJlbGF5Tm9kZToy",
+        },
+      },
+      relayConnectionFilteredField: {
+        edges: [{
+          cursor: "VGVzdFJlbGF5Tm9kZTox",
+          node: { id: "1", color: "blue" },
+        }],
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false,
+          startCursor: "VGVzdFJlbGF5Tm9kZTox",
+          endCursor: "VGVzdFJlbGF5Tm9kZTox",
         },
       },
       relayConnectionNonNullField: {

--- a/__tests__/integration/queries/object-kitchen-sink-test.js
+++ b/__tests__/integration/queries/object-kitchen-sink-test.js
@@ -15,7 +15,7 @@ describe("Integration | queries | object", function () {
     const testOptions = server.createList("test-option", 1, { name: "opt" });
     const filterableTestOptions = [
       ...testOptions,
-      server.create("test-option", { name: "Foo" })
+      server.create("test-option", { name: "Foo" }),
     ];
     const testRelayNodes = server.createList("test-relay-node", 3);
     const testUnions = [
@@ -41,7 +41,7 @@ describe("Integration | queries | object", function () {
       unionField: testUnions,
       unionNonNullField: testUnions,
       unionNestedNonNullField: testUnions,
-      unionSingularField: testUnions[0]
+      unionSingularField: testUnions[0],
     });
 
     const { testObject } = await query(objectKitchenSinkQuery, {

--- a/__tests__/integration/queries/object-kitchen-sink-test.js
+++ b/__tests__/integration/queries/object-kitchen-sink-test.js
@@ -17,10 +17,9 @@ describe("Integration | queries | object", function () {
       ...testOptions,
       server.create("test-option", { name: "Foo" }),
     ];
-    const blueTestRelayNode = server.create(
-      "test-relay-node",
-      { color: "blue" },
-    );
+    const blueTestRelayNode = server.create("test-relay-node", {
+      color: "blue",
+    });
     const testRelayNodes = [
       blueTestRelayNode,
       ...server.createList("test-relay-node", 2),
@@ -78,10 +77,12 @@ describe("Integration | queries | object", function () {
         },
       },
       relayConnectionFilteredField: {
-        edges: [{
-          cursor: "VGVzdFJlbGF5Tm9kZTox",
-          node: { id: "1", color: "blue" },
-        }],
+        edges: [
+          {
+            cursor: "VGVzdFJlbGF5Tm9kZTox",
+            node: { id: "1", color: "blue" },
+          },
+        ],
         pageInfo: {
           hasPreviousPage: false,
           hasNextPage: false,

--- a/__tests__/unit/orm/records-test.js
+++ b/__tests__/unit/orm/records-test.js
@@ -7,6 +7,7 @@ describe("Unit | ORM | records", function () {
         associations: { bars: "HasMany" },
         attrs: { name: "foo" },
         bars: [{ name: "bar" }],
+        modelName: "foo"
       };
 
       expect(adaptRecord(record, "Foo")).toEqual({
@@ -22,11 +23,13 @@ describe("Unit | ORM | records", function () {
           associations: { bars: "HasMany" },
           attrs: { name: "foo" },
           bars: [{ name: "bar" }],
+          modelName: "foo"
         },
         {
           associations: { baz: "belongsTo" },
           attrs: { name: "bar" },
           baz: { name: "baz" },
+          modelName: "foo"
         },
       ];
 
@@ -46,7 +49,10 @@ describe("Unit | ORM | records", function () {
   });
 
   describe("get records", function () {
-    const models = [{ attrs: { name: "Foo1" } }, { attrs: { name: "Foo2" } }];
+    const models = [
+      { attrs: { name: "Foo1" }, modelName: "foo" },
+      { attrs: { name: "Foo2" }, modelName: "foo" },
+    ];
     const mirageSchema = {
       foos: {
         where: jest.fn(({ name }) => ({

--- a/__tests__/unit/orm/records-test.js
+++ b/__tests__/unit/orm/records-test.js
@@ -7,7 +7,7 @@ describe("Unit | ORM | records", function () {
         associations: { bars: "HasMany" },
         attrs: { name: "foo" },
         bars: [{ name: "bar" }],
-        modelName: "foo"
+        modelName: "foo",
       };
 
       expect(adaptRecord(record, "Foo")).toEqual({
@@ -23,13 +23,13 @@ describe("Unit | ORM | records", function () {
           associations: { bars: "HasMany" },
           attrs: { name: "foo" },
           bars: [{ name: "bar" }],
-          modelName: "foo"
+          modelName: "foo",
         },
         {
           associations: { baz: "belongsTo" },
           attrs: { name: "bar" },
           baz: { name: "baz" },
-          modelName: "foo"
+          modelName: "foo",
         },
       ];
 

--- a/__tests__/unit/utils-test.js
+++ b/__tests__/unit/utils-test.js
@@ -1,9 +1,13 @@
 import { GraphQLObjectType, GraphQLScalarType } from "graphql";
 import { graphQLSchemaAST, graphQLSchema } from "@tests/gql/schema";
-import { ensureExecutableGraphQLSchema, unwrapType } from "@lib/utils";
+import {
+  capitalize,
+  ensureExecutableGraphQLSchema,
+  unwrapType
+} from "@lib/utils";
 
 describe("Unit | utils", function () {
-  describe("ensure exectuable GraphQL schema", function () {
+  describe("ensure executable GraphQL schema", function () {
     function testSchema(schemaToTest) {
       const schema = ensureExecutableGraphQLSchema(schemaToTest);
       const typeMap = schema.getTypeMap();
@@ -109,6 +113,12 @@ describe("Unit | utils", function () {
         isList: true,
         type: nonNullNodeType,
       });
+    });
+  });
+
+  describe("capitalize string", function () {
+    it("capitalizes the first letter of a string", function () {
+      expect(capitalize("foo bar")).toBe("Foo bar");
     });
   });
 });

--- a/__tests__/unit/utils-test.js
+++ b/__tests__/unit/utils-test.js
@@ -3,7 +3,7 @@ import { graphQLSchemaAST, graphQLSchema } from "@tests/gql/schema";
 import {
   capitalize,
   ensureExecutableGraphQLSchema,
-  unwrapType
+  unwrapType,
 } from "@lib/utils";
 
 describe("Unit | utils", function () {

--- a/lib/orm/records.js
+++ b/lib/orm/records.js
@@ -1,3 +1,6 @@
+import { capitalize } from "../utils";
+import { _utilsInflectorCamelize as camelize } from "miragejs";
+
 /**
  * Adapts a record from Mirage's database to return in the GraphQL response. It
  * flattens the attributes and relationships in a copy of the record. It also
@@ -6,14 +9,14 @@
  *
  * @function adaptRecord
  * @param {Object} record
- * @param {string} typeName
  * @returns {Object} A copy of the record, adapted for the response.
  */
-export function adaptRecord(record, typeName) {
+export function adaptRecord(record) {
   if (record == null) return;
 
   const { attrs, associations } = record;
-  const clone = { ...attrs, __typename: typeName };
+  const __typename = capitalize(camelize(record.modelName));
+  const clone = { ...attrs, __typename };
 
   for (let field in associations) {
     clone[field] = record[field];
@@ -28,13 +31,12 @@ export function adaptRecord(record, typeName) {
  *
  * @function adaptRecords
  * @param {Object[]} records
- * @param {string} typeName
  * @see adaptRecord
  * @returns {Object[]} A list of adapted records.
  */
-export function adaptRecords(records, typeName) {
+export function adaptRecords(records) {
   return records.reduce(function (adaptedRecords, record) {
-    return [...adaptedRecords, adaptRecord(record, typeName)];
+    return [...adaptedRecords, adaptRecord(record)];
   }, []);
 }
 
@@ -58,5 +60,31 @@ export function getRecords(type, args, mirageSchema) {
   const collectionName = mirageSchema.toCollectionName(type.name);
   const records = mirageSchema[collectionName].where(args).models;
 
-  return adaptRecords(records, type.name);
+  return adaptRecords(records);
+}
+
+/**
+ * Filters records by a hash of arguments. This is useful in cases where you
+ * have a list of records and don't need to fetch them from Mirage's database.
+ * Filtering assumes each key in `args` corresponds to an attribute of the
+ * record.
+ *
+ * For more advanced filtering needs, or sorting, for example, you will need to
+ * implement your own resolver.
+ *
+ * @function filterRecords
+ * @param {Object[]} records The records to filter.
+ * @param {Object} args Args by which to filter.
+ * @returns {Object[]} A list of filtered, adapted records.
+ */
+export function filterRecords(records, args) {
+  if (args) {
+    records = records.filter(function (record) {
+      return Object.keys(args).reduce(function (isMatch, arg) {
+        return !isMatch ? isMatch : record[arg] === args[arg];
+      }, true);
+    });
+  }
+
+  return adaptRecords(records);
 }

--- a/lib/resolvers/list.js
+++ b/lib/resolvers/list.js
@@ -1,4 +1,4 @@
-import { adaptRecords, getRecords } from "../orm/records";
+import { filterRecords, getRecords } from "../orm/records";
 import { isRelayEdgeType } from "../relay-pagination";
 
 /**
@@ -21,5 +21,5 @@ export default function resolveList(obj, args, context, info, type) {
     ? getRecords(type, args, context.mirageSchema)
     : isRelayEdgeType(type)
     ? obj.edges
-    : adaptRecords(obj[info.fieldName].models, type.name);
+    : filterRecords(obj[info.fieldName].models, args);
 }

--- a/lib/resolvers/object.js
+++ b/lib/resolvers/object.js
@@ -43,5 +43,5 @@ export default function resolveObject(obj, args, context, info, type) {
     ? obj.node
     : isRelayPageInfoType(type)
     ? obj.pageInfo
-    : adaptRecord(obj[info.fieldName], type.name);
+    : adaptRecord(obj[info.fieldName]);
 }

--- a/lib/resolvers/relay.js
+++ b/lib/resolvers/relay.js
@@ -23,7 +23,7 @@ export function resolveRelayConnection(obj, args, context, info, type) {
   const { type: nodeType } = unwrapType(edgeType.getFields().node.type);
   const records =
     obj && obj[info.fieldName] && obj[info.fieldName].models
-      ? adaptRecords(obj[info.fieldName].models, nodeType.name)
+      ? adaptRecords(obj[info.fieldName].models)
       : getRecords(nodeType, nonRelayArgs, context.mirageSchema);
   const edges = getEdges(records, relayArgs, nodeType.name);
 

--- a/lib/resolvers/relay.js
+++ b/lib/resolvers/relay.js
@@ -1,5 +1,5 @@
 import { getEdges, getPageInfo, getRelayArgs } from "../relay-pagination";
-import { getRecords, adaptRecords } from "../orm/records";
+import { filterRecords, getRecords } from "../orm/records";
 import { unwrapType } from "../utils";
 
 /**
@@ -23,7 +23,7 @@ export function resolveRelayConnection(obj, args, context, info, type) {
   const { type: nodeType } = unwrapType(edgeType.getFields().node.type);
   const records =
     obj && obj[info.fieldName] && obj[info.fieldName].models
-      ? adaptRecords(obj[info.fieldName].models)
+      ? filterRecords(obj[info.fieldName].models, nonRelayArgs)
       : getRecords(nodeType, nonRelayArgs, context.mirageSchema);
   const edges = getEdges(records, relayArgs, nodeType.name);
 

--- a/lib/resolvers/union.js
+++ b/lib/resolvers/union.js
@@ -1,4 +1,10 @@
-import { getRecords } from "../orm/records";
+import { adaptRecord, filterRecords, getRecords } from "../orm/records";
+
+function getRecordsForTypes(types, args, mirageSchema) {
+  return types.reduce(function (records, type) {
+    return [...records, ...getRecords(type, args, mirageSchema)];
+  }, []);
+}
 
 /**
  * Resolves a field that returns a union type. For each type in the union, it
@@ -14,11 +20,10 @@ import { getRecords } from "../orm/records";
  * @see {@link https://graphql.org/learn/execution/#root-fields-resolvers}
  * @returns {Object[]} A list of records of many types from Mirage's database.
  */
-export default function resolveUnion(_obj, args, context, _info, isList, type) {
-  const types = type.getTypes();
-  const recordsForTypes = types.reduce(function (records, type) {
-    return [...records, ...getRecords(type, args, context.mirageSchema)];
-  }, []);
-
-  return isList ? recordsForTypes : recordsForTypes[0];
+export default function resolveUnion(obj, args, context, info, isList, type) {
+  return !obj
+    ? getRecordsForTypes(type.getTypes(), args, context.mirageSchema)
+    : isList
+    ? filterRecords(obj[info.fieldName].models, args)
+    : adaptRecord(obj[info.fieldName]);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,17 @@ import {
 } from "graphql";
 
 /**
+ * Capitalize a string
+ *
+ * @function capitalize
+ * @param {String} str
+ * @returns {String} The capitalized string.
+ */
+export function capitalize(str) {
+  return `${str.charAt(0).toUpperCase()}${str.slice(1)}`;
+}
+
+/**
  * Given a GraphQL schema which may be a string or an AST, it returns an
  * executable version of that schema. If the schema passed in is already
  * executable, it returns the schema as-is.


### PR DESCRIPTION
This PR fixes somewhat related issues #18 and #19 where, respectively, union type resolution can fail when there's a parent object and filtering for related has-many records fails.

A function to filter related records was added and is now called when resolving list types and a list of union types.

Additionally, the type name parameter was removed from the functions that adapt records as this is essentially already present on the record from Mirage's database and doesn't need to be passed in.

Fixes #16.
Fixes #18.
Fixes #19.