### PR TITLE
Fix getting variable types in auto-mutation resolver

### DIFF
--- a/__tests__/gql/mutations/create-non-null.gql
+++ b/__tests__/gql/mutations/create-non-null.gql
@@ -1,0 +1,6 @@
+mutation CreateTestObjectNonNull($input: TestObjectInput!) {
+  createTestObjectNonNull(input: $input) {
+    id
+    size
+  }
+}

--- a/__tests__/gql/mutations/create.gql
+++ b/__tests__/gql/mutations/create.gql
@@ -1,4 +1,4 @@
-mutation CreateTestObject($input: TestObjectInput!) {
+mutation CreateTestObject($input: TestObjectInput) {
   createTestObject(input: $input) {
     id
     size

--- a/__tests__/gql/mutations/update-non-null.gql
+++ b/__tests__/gql/mutations/update-non-null.gql
@@ -1,0 +1,6 @@
+mutation UpdateTestObjectNonNull($id: ID!, $input: TestObjectInput!) {
+  updateTestObjectNonNull(id: $id, input: $input) {
+    id
+    size
+  }
+}

--- a/__tests__/gql/mutations/update.gql
+++ b/__tests__/gql/mutations/update.gql
@@ -1,4 +1,4 @@
-mutation UpdateTestObject($id: ID!, $input: TestObjectInput!) {
+mutation UpdateTestObject($id: ID!, $input: TestObjectInput) {
   updateTestObject(id: $id, input: $input) {
     id
     size

--- a/__tests__/gql/schema.gql
+++ b/__tests__/gql/schema.gql
@@ -8,11 +8,13 @@ interface TestInterface {
 }
 
 type Mutation {
-  createTestObject(input: TestObjectInput!): TestObject
+  createTestObject(input: TestObjectInput): TestObject
+  createTestObjectNonNull(input: TestObjectInput!): TestObject
   deleteTestObject(id: ID!): TestObject
   optionallyMutateTestObject(id: ID!, input: TestObjectInput!): TestObject
   unimplemented: TestObject
-  updateTestObject(id: ID!, input: TestObjectInput!): TestObject
+  updateTestObject(id: ID!, input: TestObjectInput): TestObject
+  updateTestObjectNonNull(id: ID!, input: TestObjectInput!): TestObject
 }
 
 type PageInfo {
@@ -89,19 +91,13 @@ type TestObject {
   hasManyNestedNonNullField: [TestOption!]!
   interfaceField: TestInterface
   interfaceNonNullField: TestInterface!
-  relayConnectionField(
+  relayConnectionField(first: Int, after: String): TestRelayConnection
+  relayConnectionFilteredField(
     first: Int
     after: String
-  ): TestRelayConnection
-  relayConnectionFilteredField(
-    first: Int,
-    after: String,
     color: String
   ): TestRelayConnection
-  relayConnectionNonNullField(
-    last: Int
-    before: String
-  ): TestRelayConnection!
+  relayConnectionNonNullField(last: Int, before: String): TestRelayConnection!
   size: String
   sizeNonNull: String!
   unionField: [TestUnion]

--- a/__tests__/integration/mutations/create-object-test.js
+++ b/__tests__/integration/mutations/create-object-test.js
@@ -1,10 +1,19 @@
 import createTestObjectMutation from "@tests/gql/mutations/create.gql";
+import createTestObjectNonNullMutation from "@tests/gql/mutations/create-non-null.gql";
 import { mutate, startServer } from "@tests/integration/setup";
 
-describe("Integration | mutations | create", function () {
-  it("can create a test object", async function () {
-    const server = startServer();
+let server;
 
+describe("Integration | mutations | create", function () {
+  beforeEach(function () {
+    server = startServer();
+  });
+
+  afterEach(function () {
+    server.shutdown();
+  });
+
+  it("can create a test object", async function () {
     const { createTestObject } = await mutate(createTestObjectMutation, {
       variables: {
         input: { size: "M" },
@@ -13,6 +22,22 @@ describe("Integration | mutations | create", function () {
     const record = server.schema.testObjects.first();
 
     expect(createTestObject).toEqual({ id: "1", size: "M" });
+    expect(record.id).toBe("1");
+    expect(record.size).toBe("M");
+  });
+
+  it("can create a test object (non-null input type)", async function () {
+    const { createTestObjectNonNull } = await mutate(
+      createTestObjectNonNullMutation,
+      {
+        variables: {
+          input: { size: "M" },
+        },
+      }
+    );
+    const record = server.schema.testObjects.first();
+
+    expect(createTestObjectNonNull).toEqual({ id: "1", size: "M" });
     expect(record.id).toBe("1");
     expect(record.size).toBe("M");
   });

--- a/__tests__/integration/mutations/update-object-test.js
+++ b/__tests__/integration/mutations/update-object-test.js
@@ -1,10 +1,19 @@
 import updateTestObjectMutation from "@tests/gql/mutations/update.gql";
+import updateTestObjectNonNullMutation from "@tests/gql/mutations/update-non-null.gql";
 import { mutate, startServer } from "@tests/integration/setup";
 
-describe("Integration | mutations | create", function () {
-  it("can create a test object", async function () {
-    const server = startServer();
+let server;
 
+describe("Integration | mutations | create", function () {
+  beforeEach(function () {
+    server = startServer();
+  });
+
+  afterEach(function () {
+    server.shutdown();
+  });
+
+  it("can update a test object", async function () {
     server.create("test-object", { size: "M" });
 
     const { updateTestObject } = await mutate(updateTestObjectMutation, {
@@ -13,6 +22,21 @@ describe("Integration | mutations | create", function () {
     const record = server.schema.testObjects.first();
 
     expect(updateTestObject).toEqual({ id: "1", size: "L" });
+    expect(record.size).toBe("L");
+  });
+
+  it("can update a test object (non-null input)", async function () {
+    server.create("test-object", { size: "M" });
+
+    const { updateTestObjectNonNull } = await mutate(
+      updateTestObjectNonNullMutation,
+      {
+        variables: { id: "1", input: { size: "L" } },
+      }
+    );
+    const record = server.schema.testObjects.first();
+
+    expect(updateTestObjectNonNull).toEqual({ id: "1", size: "L" });
     expect(record.size).toBe("L");
   });
 });

--- a/lib/resolvers/mutation.js
+++ b/lib/resolvers/mutation.js
@@ -1,9 +1,8 @@
-import { unwrapType } from "../utils";
 import { isInputObjectType, isSpecifiedScalarType } from "graphql";
 
 function getMutationVarTypes(variableDefinitions, typeMap) {
   return variableDefinitions.reduce(function (vars, definition) {
-    const { type: typeInfo } = unwrapType(definition.type.type);
+    const typeInfo = definition.type.type || definition.type;
     const type = typeMap[typeInfo.name.value];
 
     return [...vars, type];


### PR DESCRIPTION
This PR fixes an issue where variable types weren't understood correctly when trying to auto-resolve mutations. Originally, we used the `unwrapType` utility to determine the variable type but this doesn't actually work.