### PR TITLE
Add request from Mirage to resolver context

### DIFF
--- a/__tests__/integration/handler-test.js
+++ b/__tests__/integration/handler-test.js
@@ -29,7 +29,7 @@ function startServer({ resolvers }) {
 }
 
 describe("Integration | handler", function () {
-  it("resolver context gets the Mirage schema and request", async function () {
+  test("resolver context gets Mirage schema and request", async function () {
     expect.assertions(2);
 
     const server = startServer({

--- a/__tests__/integration/handler-test.js
+++ b/__tests__/integration/handler-test.js
@@ -1,0 +1,54 @@
+import contextQuery from "@tests/gql/queries/context.gql";
+import { createGraphQLHandler } from "../../lib/handler";
+import { createServer } from "miragejs";
+import { graphQLSchema } from "@tests/gql/schema";
+import { query } from "@tests/integration/setup";
+
+let mirageSchema;
+let request;
+
+function startServer({ resolvers }) {
+  const server = createServer({
+    routes() {
+      this.post("/graphql", (_schema, _request) => {
+        mirageSchema = this.schema;
+        request = _request;
+
+        const handler = createGraphQLHandler(graphQLSchema, mirageSchema, {
+          resolvers,
+        });
+
+        return handler(_schema, _request);
+      });
+    },
+  });
+
+  server.logging = false;
+
+  return server;
+}
+
+describe("Integration | handler", function () {
+  it("resolver context gets the Mirage schema and request", async function () {
+    expect.assertions(2);
+
+    const server = startServer({
+      resolvers: {
+        Query: {
+          testContext(_obj, _args, context) {
+            expect(context.mirageSchema).toBe(mirageSchema);
+            expect(context.request).toBe(request);
+
+            return "foo";
+          },
+        },
+      },
+    });
+
+    server.logging = false;
+
+    await query(contextQuery);
+
+    server.shutdown();
+  });
+});

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -24,7 +24,8 @@ import { graphql } from "graphql";
  *    sorting records and complex mutations.
  * 2. `context` - A context object that GraphQL will pass into each resolver. A
  *     common use case for this is to supply current user information to
- *     resolvers.
+ *     resolvers. By default, whatever context you pass in will be appended with
+ *     a reference to the Mirage schema and the request being handled.
  * 3. `root` - A root level value that GraphQL will use as the parent object for
  *    fields at the highest level.
  *
@@ -55,19 +56,21 @@ export function createGraphQLHandler(
 ) {
   const contextValue = { ...context, mirageSchema };
   const fieldResolver = createFieldResolver(resolvers);
-  const schema = ensureExecutableGraphQLSchema(graphQLSchema);
 
-  ensureModels({ graphQLSchema: schema, mirageSchema });
+  ensureModels({
+    graphQLSchema: ensureExecutableGraphQLSchema(graphQLSchema),
+    mirageSchema,
+  });
 
   return function graphQLHandler(_mirageSchema, request) {
     try {
       const { query, variables } = JSON.parse(request.requestBody);
 
       return graphql({
-        contextValue,
+        contextValue: { ...contextValue, request },
         fieldResolver,
         rootValue: root,
-        schema,
+        schema: graphQLSchema,
         source: query,
         variableValues: variables,
       });


### PR DESCRIPTION
It would be nice to extend the default resolver context by adding a reference to the request being handled in addition to Mirage's schema that's already passed in.