### PR TITLE
Fix issue with parsing GraphQL schemas

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -57,10 +57,9 @@ export function createGraphQLHandler(
   const contextValue = { ...context, mirageSchema };
   const fieldResolver = createFieldResolver(resolvers);
 
-  ensureModels({
-    graphQLSchema: ensureExecutableGraphQLSchema(graphQLSchema),
-    mirageSchema,
-  });
+  graphQLSchema = ensureExecutableGraphQLSchema(graphQLSchema);
+
+  ensureModels({ graphQLSchema, mirageSchema });
 
   return function graphQLHandler(_mirageSchema, request) {
     try {


### PR DESCRIPTION
This PR fixes an issue introduced by #22 where the GraphQL schema passed into the handler isn't parsed in the right places.

An integration test was updated to make sure the GraphQL schema is parsed in the handler.