### PR TITLE
Update resolver definitions for correct typescript compile

### DIFF
--- a/lib/resolvers/field.js
+++ b/lib/resolvers/field.js
@@ -16,7 +16,7 @@ function getOptionalResolver(info, optionalResolvers) {
  * resolver.
  *
  * @callback fieldResolver
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info

--- a/lib/resolvers/interface.js
+++ b/lib/resolvers/interface.js
@@ -35,7 +35,7 @@ function resolveFromImplementations(obj, args, context, info, type) {
  * either case, it delegates to `resolveObject`.
  *
  * @function resolveInterface
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info

--- a/lib/resolvers/list.js
+++ b/lib/resolvers/list.js
@@ -8,7 +8,7 @@ import { isRelayEdgeType } from "../relay-pagination";
  * optional resolver should be passed into the GraphQL handler.
  *
  * @function resolveList
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info

--- a/lib/resolvers/mirage.js
+++ b/lib/resolvers/mirage.js
@@ -19,7 +19,7 @@ import { unwrapType } from "../utils";
  * if the records are fetched using this resolver before sorting them.
  *
  * @function mirageGraphQLFieldResolver
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info
@@ -34,7 +34,7 @@ export default function mirageGraphQLFieldResolver(obj, args, context, info) {
     : isUnionType(type)
     ? resolveUnion(obj, args, context, info, isList, type)
     : !isObjectType(type)
-    ? resolveDefault(...arguments)
+    ? resolveDefault(obj, args, context, info)
     : isList
     ? resolveList(obj, args, context, info, type)
     : resolveObject(obj, args, context, info, type);

--- a/lib/resolvers/mutation.js
+++ b/lib/resolvers/mutation.js
@@ -72,10 +72,10 @@ function throwUnimplemented(info) {
  * handler.
  *
  * @function resolveMutation
- * @param {Object} [obj]
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info
+ * @param {String} typeName
  * @see {@link https://graphql.org/learn/execution/#root-fields-resolvers}
  * @throws It will throw an error if the mutation cannot be handled by default.
  * @returns {Object} The affected record from Mirage's database.

--- a/lib/resolvers/object.js
+++ b/lib/resolvers/object.js
@@ -23,7 +23,7 @@ function isMutation(info) {
  * Resolves a field that returns an object type.
  *
  * @function resolveObject
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info

--- a/lib/resolvers/relay.js
+++ b/lib/resolvers/relay.js
@@ -8,10 +8,11 @@ import { unwrapType } from "../utils";
  * edges and page info for the connection.
  *
  * @function resolveRelayConnection
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info
+ * @param {Object} type
  * @see {@link https://relay.dev/graphql/connections.htm#sec-Connection-Types}
  * @see {@link https://graphql.org/learn/execution/#root-fields-resolvers}
  * @returns {{edges: Object[], pageInfo: Object}}

--- a/lib/resolvers/union.js
+++ b/lib/resolvers/union.js
@@ -11,7 +11,7 @@ function getRecordsForTypes(types, args, mirageSchema) {
  * fetches and filters records from Mirage's database.
  *
  * @function resolveUnion
- * @param {Object} [obj]
+ * @param {Object} obj
  * @param {Object} args
  * @param {Object} context
  * @param {Object} info


### PR DESCRIPTION
Related Issue: [#25](https://github.com/miragejs/graphql/issues/25)
node-tsc seems to be finicky with how it compiles.

Two issues here were
 - obj param was compiling as optional: definition syntax change fixed that
 - args was compiling as multiple arguments: change from `...arguments` to just the arguments fixed that

I don't see that the change to `resolveDefault()` will cause any issues, but you should be able to check that.