### PR TITLE
Add ability to create POJO with model info from graphql schema

### DIFF
--- a/__tests__/unit/orm/models-test.js
+++ b/__tests__/unit/orm/models-test.js
@@ -1,69 +1,213 @@
-import { ensureModels } from "@lib/orm/models";
+import { ensureModels, createModels } from "@lib/orm/models";
 import { graphQLSchema } from "@tests/gql/schema";
 
 describe("Unit | ORM | models", function () {
-  const registeredModels = {};
-  const mirageSchema = {
-    hasModelForModelName: () => false,
-    registerModel(typeName, model) {
-      registeredModels[typeName] = model;
-    },
-  };
+  describe("ensureModels", function () {
+    const registeredModels = {};
+    const mirageSchema = {
+      hasModelForModelName: () => false,
+      registerModel(typeName, model) {
+        registeredModels[typeName] = model;
+      },
+    };
 
-  ensureModels({ graphQLSchema, mirageSchema });
+    ensureModels({ graphQLSchema, mirageSchema });
 
-  it("does not register a model for the mutation type", function () {
-    expect(registeredModels.Mutation).toBeUndefined();
-  });
-
-  it("does not register a model for the query type", function () {
-    expect(registeredModels.Query).toBeUndefined();
-  });
-
-  it("does not register a model for the subscription type", function () {
-    expect(registeredModels.Subscription).toBeUndefined();
-  });
-
-  describe("TestObject relationships", function () {
-    const model = new registeredModels.TestObject({}, "TestObject");
-
-    function testRelationship(
-      name,
-      type,
-      modelName,
-      { isPolymorphic = false } = {}
-    ) {
-      expect(model.__proto__[name].constructor.name).toBe(type);
-      expect(model.__proto__[name].modelName).toBe(modelName);
-      expect(model.__proto__[name].opts.polymorphic).toBe(isPolymorphic);
-    }
-
-    // eslint-disable-next-line jest/expect-expect
-    it("belongs to test category", function () {
-      testRelationship("belongsToField", "BelongsTo", "test-category");
+    it("does not register a model for the mutation type", function () {
+      expect(registeredModels.Mutation).toBeUndefined();
     });
 
-    // eslint-disable-next-line jest/expect-expect
-    it("has many test options", function () {
-      testRelationship("hasManyField", "HasMany", "test-option");
+    it("does not register a model for the query type", function () {
+      expect(registeredModels.Query).toBeUndefined();
     });
 
-    // eslint-disable-next-line jest/expect-expect
-    it("belongs to test interface", function () {
-      testRelationship("interfaceField", "BelongsTo", "test-interface", {
-        isPolymorphic: true,
+    it("does not register a model for the subscription type", function () {
+      expect(registeredModels.Subscription).toBeUndefined();
+    });
+
+    it("does register the TestObject model", function () {
+      expect(registeredModels.TestObject).toBeDefined();
+    });
+
+    it("does register the TestCategory model", function () {
+      expect(registeredModels.TestCategory).toBeDefined();
+    });
+
+    it("does register the TestOption model", function () {
+      expect(registeredModels.TestOption).toBeDefined();
+    });
+
+    it("does not register the TestInterface model", function () {
+      expect(registeredModels.TestInterface).toBeUndefined();
+    });
+
+    it("does register the TestImplOne model", function () {
+      expect(registeredModels.TestImplOne).toBeDefined();
+    });
+
+    it("does register the TestImplTwo model", function () {
+      expect(registeredModels.TestImplTwo).toBeDefined();
+    });
+
+    it("does not register the TestUnion model", function () {
+      expect(registeredModels.TestUnion).toBeUndefined();
+    });
+
+    it("does register the TestUnionOne model", function () {
+      expect(registeredModels.TestUnionOne).toBeDefined();
+    });
+
+    it("does register the TestUnionTwo model", function () {
+      expect(registeredModels.TestUnionTwo).toBeDefined();
+    });
+
+    describe("TestObject relationships", function () {
+      const model = new registeredModels.TestObject({}, "TestObject");
+
+      function testRelationship(
+        name,
+        type,
+        modelName,
+        { isPolymorphic = false } = {}
+      ) {
+        expect(model.__proto__[name].constructor.name).toBe(type);
+        expect(model.__proto__[name].modelName).toBe(modelName);
+        expect(model.__proto__[name].opts.polymorphic).toBe(isPolymorphic);
+      }
+
+      // eslint-disable-next-line jest/expect-expect
+      it("belongs to test category", function () {
+        testRelationship("belongsToField", "BelongsTo", "test-category");
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("has many test options", function () {
+        testRelationship("hasManyField", "HasMany", "test-option");
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("belongs to test interface", function () {
+        testRelationship("interfaceField", "BelongsTo", "test-interface", {
+          isPolymorphic: true,
+        });
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("has many test relay nodes", function () {
+        testRelationship("relayConnectionField", "HasMany", "test-relay-node");
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("has many test unions", function () {
+        testRelationship("unionField", "HasMany", "test-union", {
+          isPolymorphic: true,
+        });
       });
     });
+  });
 
-    // eslint-disable-next-line jest/expect-expect
-    it("has many test relay nodes", function () {
-      testRelationship("relayConnectionField", "HasMany", "test-relay-node");
+  describe("createModels", function () {
+    const models = createModels({ graphQLSchema });
+
+    function findModel(name) {
+      return models.find((model) => model.name == name);
+    }
+
+    it("does not create a model for the mutation type", function () {
+      expect(findModel("Mutation")).toBeUndefined();
     });
 
-    // eslint-disable-next-line jest/expect-expect
-    it("has many test unions", function () {
-      testRelationship("unionField", "HasMany", "test-union", {
-        isPolymorphic: true,
+    it("does not create a model for the query type", function () {
+      expect(findModel("Query")).toBeUndefined();
+    });
+
+    it("does not create a model for the subscription type", function () {
+      expect(findModel("Subscription")).toBeUndefined();
+    });
+
+    it("does create the TestObject model", function () {
+      expect(findModel("TestObject")).toBeDefined();
+    });
+
+    it("does create the TestCategory model", function () {
+      expect(findModel("TestCategory")).toBeDefined();
+    });
+
+    it("does create the TestOption model", function () {
+      expect(findModel("TestOption")).toBeDefined();
+    });
+
+    it("does not create the TestInterface model", function () {
+      expect(findModel("TestInterface")).toBeUndefined();
+    });
+
+    it("does create the TestImplOne model", function () {
+      expect(findModel("TestImplOne")).toBeDefined();
+    });
+
+    it("does create the TestImplTwo model", function () {
+      expect(findModel("TestImplTwo")).toBeDefined();
+    });
+
+    it("does not create the TestUnion model", function () {
+      expect(findModel("TestUnion")).toBeUndefined();
+    });
+
+    it("does create the TestUnionOne model", function () {
+      expect(findModel("TestUnionOne")).toBeDefined();
+    });
+
+    it("does create the TestUnionTwo model", function () {
+      expect(findModel("TestUnionTwo")).toBeDefined();
+    });
+
+    describe("TestObject relationships", function () {
+      const model = findModel("TestObject");
+
+      function findRelationship(model, fieldName) {
+        return model.associations.find((item) => item.fieldName == fieldName);
+      }
+
+      function testRelationship(
+        fieldName,
+        type,
+        associationName,
+        { isPolymorphic = false } = {}
+      ) {
+        const rel = findRelationship(model, fieldName);
+        expect(rel).toBeDefined();
+        expect(rel.name).toBe(associationName);
+        expect(rel.type).toBe(type);
+        expect(rel.options.polymorphic).toBe(isPolymorphic);
+      }
+
+      // eslint-disable-next-line jest/expect-expect
+      it("belongs to test category", function () {
+        testRelationship("belongsToField", "belongsTo", "testCategory");
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("has many test options", function () {
+        testRelationship("hasManyField", "hasMany", "testOption");
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("belongs to test interface", function () {
+        testRelationship("interfaceField", "belongsTo", "testInterface", {
+          isPolymorphic: true,
+        });
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("has many test relay nodes", function () {
+        testRelationship("relayConnectionField", "hasMany", "testRelayNode");
+      });
+
+      // eslint-disable-next-line jest/expect-expect
+      it("has many test unions", function () {
+        testRelationship("unionField", "hasMany", "testUnion", {
+          isPolymorphic: true,
+        });
       });
     });
   });

--- a/lib/orm/models.js
+++ b/lib/orm/models.js
@@ -14,8 +14,8 @@ function isAssociationType(type) {
   return ASSOCIATION_TYPE_CHECKS.find((checkType) => checkType(type));
 }
 
-function createAssociationOptionsForFields(fields) {
-  return function (associationOptions, fieldName) {
+function createAssociationForFields(fields) {
+  return function (associations, fieldName) {
     const fieldType = fields[fieldName].type;
     const { isList, type: unwrappedType } = unwrapType(fieldType, {
       considerRelay: true,
@@ -28,39 +28,85 @@ function createAssociationOptionsForFields(fields) {
           isInterfaceType(unwrappedType) || isUnionType(unwrappedType),
       };
 
-      associationOptions[fieldName] = isList
-        ? hasMany(associationName, options)
-        : belongsTo(associationName, options);
+      associations.push({
+        name: associationName,
+        fieldName: fieldName,
+        type: isList ? "hasMany" : "belongsTo",
+        options,
+      });
     }
 
-    return associationOptions;
+    return associations;
   };
 }
 
-function createAssociationOptions(type) {
+function createAssociations(type) {
   const fields = type.getFields();
-  const associationOptions = Object.keys(fields).reduce(
-    createAssociationOptionsForFields(fields),
-    {}
-  );
-
-  return associationOptions;
+  return Object.keys(fields).reduce(createAssociationForFields(fields), []);
 }
 
-function ensureModel(mirageSchema, type) {
-  const associationOptions = createAssociationOptions(type);
-  const model = Model.extend(associationOptions);
-
-  mirageSchema.registerModel(type.name, model);
+function createModel(type) {
+  return {
+    name: type.name,
+    camelizedName: camelize(type.name),
+    associations: createAssociations(type),
+  };
 }
 
-function shouldAddModel(mirageSchema, type) {
+function shouldCreateModel(type) {
   return (
-    !mirageSchema.hasModelForModelName(type.name) &&
-    isObjectType(type) &&
-    !isRelayType(type) &&
-    !type.name.startsWith("__")
+    isObjectType(type) && !isRelayType(type) && !type.name.startsWith("__")
   );
+}
+
+function shouldRegisterModel(mirageSchema, name) {
+  return !mirageSchema.hasModelForModelName(name);
+}
+
+function createAssociationOptions(model) {
+  return model.associations.reduce(function (options, association) {
+    options[association.fieldName] =
+      association.type === "hasMany"
+        ? hasMany(association.name, association.options)
+        : belongsTo(association.name, association.options);
+
+    return options;
+  }, {});
+}
+
+function registerModel(mirageSchema, model) {
+  const options = createAssociationOptions(model);
+  mirageSchema.registerModel(model.name, Model.extend(options));
+}
+
+/**
+ * Create a POJO for all model definitions from the Graphql Schema. It figures
+ * out all the models and their relationships that need to be established for
+ * the Mirage Schema.
+ *
+ * Use this data to generate Mirage Models. This is the underlining
+ * implementation of `ensureModels`.
+ *
+ * @function createModels
+ * @param {{graphQLSchema: Object} options
+ */
+export function createModels({ graphQLSchema }) {
+  const graphQLSchemaQueryTypes = [
+    graphQLSchema.getMutationType(),
+    graphQLSchema.getQueryType(),
+    graphQLSchema.getSubscriptionType(),
+  ];
+  const typeMap = graphQLSchema.getTypeMap();
+
+  return Object.keys(typeMap).reduce(function (models, typeName) {
+    const { type } = unwrapType(typeMap[typeName]);
+    const isQueryType = graphQLSchemaQueryTypes.includes(type);
+
+    if (shouldCreateModel(type) && !isQueryType) {
+      models.push(createModel(type));
+    }
+    return models;
+  }, []);
 }
 
 /**
@@ -78,19 +124,11 @@ function shouldAddModel(mirageSchema, type) {
  * @param {{graphQLSchema: Object, mirageSchema: Object}} options
  */
 export function ensureModels({ graphQLSchema, mirageSchema }) {
-  const graphQLSchemaQueryTypes = [
-    graphQLSchema.getMutationType(),
-    graphQLSchema.getQueryType(),
-    graphQLSchema.getSubscriptionType(),
-  ];
-  const typeMap = graphQLSchema.getTypeMap();
+  const models = createModels({ graphQLSchema });
 
-  Object.keys(typeMap).forEach(function (typeName) {
-    const { type } = unwrapType(typeMap[typeName]);
-    const isQueryType = graphQLSchemaQueryTypes.includes(type);
-
-    if (shouldAddModel(mirageSchema, type) && !isQueryType) {
-      ensureModel(mirageSchema, type);
+  models.forEach(function (model) {
+    if (shouldRegisterModel(mirageSchema, model.name)) {
+      registerModel(mirageSchema, model);
     }
   });
 }


### PR DESCRIPTION
Refactor the `ensureModels` function into a lower-level method that returns a POJO with all the model info and their associations. `ensureModels` then uses that lower-level function to add models to Mirage. Making this change a non-breaking change.

This new `createModels` function can be used to create models in a different way. My use case is to build a code generator that actually generates the code for Mirage Models from the GraphQL schema. The goal is to have all hardcoded models so folks using TypeScript can have these model definitions for type checking.

