### PR TITLE
Fix issue with resolving list types when parent is a POJO

### DIFF
--- a/__tests__/unit/resolvers/list-resolver-test.js
+++ b/__tests__/unit/resolvers/list-resolver-test.js
@@ -1,0 +1,54 @@
+jest.mock("@lib/orm/records");
+
+import { filterRecords, getRecords } from "@lib/orm/records";
+import resolveList from "@lib/resolvers/list";
+
+describe("Unit | resolvers | list", function () {
+  describe("without a parent record", function () {
+    const obj = undefined;
+    const args = {};
+    const type = {};
+    const context = { mirageSchema: {} };
+
+    it("finds records for the given type and args", function () {
+      resolveList(obj, args, context, undefined, type);
+
+      expect(getRecords).toHaveBeenCalledWith(type, args, context.mirageSchema);
+    });
+  });
+
+  describe("parent records", function () {
+    it("returns edges of parent, if type is a Relay edge", function () {
+      const obj = { edges: [] };
+      const type = {
+        name: "TestEdge",
+        getFields: () => ({ node: undefined }),
+      };
+      const edges = resolveList(obj, undefined, undefined, undefined, type);
+
+      expect(edges).toEqual(obj.edges);
+    });
+
+    it("can filter records included with the parent record", function () {
+      const obj = { bars: [] };
+      const args = {};
+      const info = { fieldName: "bars" };
+      const type = { name: "Foo" };
+
+      resolveList(obj, args, undefined, info, type);
+
+      expect(filterRecords).toHaveBeenCalledWith(obj.bars, args);
+    });
+
+    it("can filter records related to a Mirage record", function () {
+      const obj = { bars: { models: [] } };
+      const args = {};
+      const info = { fieldName: "bars" };
+      const type = { name: "Foo" };
+
+      resolveList(obj, args, undefined, info, type);
+
+      expect(filterRecords).toHaveBeenCalledWith(obj.bars.models, args);
+    });
+  });
+});

--- a/lib/orm/__mocks__/records.js
+++ b/lib/orm/__mocks__/records.js
@@ -1,0 +1,2 @@
+export const filterRecords = jest.fn(() => {});
+export const getRecords = jest.fn(() => {});

--- a/lib/resolvers/list.js
+++ b/lib/resolvers/list.js
@@ -1,6 +1,10 @@
 import { filterRecords, getRecords } from "../orm/records";
 import { isRelayEdgeType } from "../relay-pagination";
 
+function getRelatedRecords(obj, fieldName) {
+  return obj[fieldName].models || obj[fieldName];
+}
+
 /**
  * Resolves fields that return a list type. Note: If there's no parent object,
  * this only works for lists that return a list of records from Mirage's
@@ -21,5 +25,5 @@ export default function resolveList(obj, args, context, info, type) {
     ? getRecords(type, args, context.mirageSchema)
     : isRelayEdgeType(type)
     ? obj.edges
-    : filterRecords(obj[info.fieldName].models, args);
+    : filterRecords(getRelatedRecords(obj, info.fieldName), args);
 }


### PR DESCRIPTION
This PR fixes an issue where resolving list type fields of POJO parent records breaks because the library assumes the parent is always a Mirage record.